### PR TITLE
Remove description from error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,11 +63,7 @@ where
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MemDBError {}
 
-impl Error for MemDBError {
-    fn description(&self) -> &str {
-        "mem db error"
-    }
-}
+impl Error for MemDBError {}
 
 impl fmt::Display for MemDBError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
It's unnecessary to implement description() for user defined errors, so just omit it.

See: [https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.description](https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.description)

