### PR TITLE
fix(codec): decode pair

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ tiny-keccak = "1.4.2"
 [dev-dependencies]
 rand = "0.6.3"
 hex = "0.3.2"
+ethereum-types = "0.5.2"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -59,7 +59,15 @@ impl NodeCodec for RLPNodeCodec {
             Prototype::Data(0) => Ok(f(DataType::Empty)?),
             Prototype::List(2) => {
                 let key = r.at(0)?.data()?;
-                let value = r.at(1)?.data()?;
+                let rlp_data = r.at(1)?;
+                // TODO: if “is_data == true”, the value of the leaf node
+                // This is not a good implementation
+                // the details of MPT should not be exposed to the user.
+                let value = if rlp_data.is_data() {
+                    rlp_data.data()?
+                } else {
+                    rlp_data.as_raw()
+                };
 
                 Ok(f(DataType::Pair(&key, &value))?)
             }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -637,4 +637,38 @@ mod tests {
         let removed = trie.remove(b"test23").unwrap();
         assert_eq!(true, removed);
     }
+
+    #[test]
+    fn test_multiple_trie_roots() {
+        let root1 = {
+            let mut db = MemoryDB::new();
+            let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
+            trie.insert(b"a", b"a").unwrap();
+            trie.root().unwrap()
+        };
+
+        let root2 = {
+            let mut db = MemoryDB::new();
+            let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
+            trie.insert(b"a", b"a").unwrap();
+            trie.insert(b"b", b"b").unwrap();
+            trie.root().unwrap();
+            trie.remove(b"b").unwrap();
+            trie.root().unwrap()
+        };
+
+        let root3 = {
+            let mut db = MemoryDB::new();
+            let mut t1 = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
+            t1.insert(b"a", b"a").unwrap();
+            t1.insert(b"b", b"b").unwrap();
+            let root = t1.root().unwrap();
+            let mut t2 = PatriciaTrie::from(&mut db, RLPNodeCodec::default(), &root).unwrap();
+            t2.remove(b"b").unwrap();
+            t2.root().unwrap()
+        };
+
+        assert_eq!(root1, root2);
+        assert_eq!(root2, root3);
+    }
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -486,6 +486,8 @@ mod tests {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
 
+    use ethereum_types;
+
     use super::{PatriciaTrie, Trie};
     use crate::codec::{NodeCodec, RLPNodeCodec};
     use crate::db::MemoryDB;
@@ -647,31 +649,36 @@ mod tests {
 
     #[test]
     fn test_multiple_trie_roots() {
+        let k0: ethereum_types::H256 = 0.into();
+        let k1: ethereum_types::H256 = 1.into();
+        let v: ethereum_types::H256 = 0x1234.into();
+
         let root1 = {
             let mut db = MemoryDB::new();
             let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
-            trie.insert(b"a", b"a").unwrap();
+            trie.insert(k0.as_ref(), v.as_ref()).unwrap();
             trie.root().unwrap()
         };
 
         let root2 = {
             let mut db = MemoryDB::new();
             let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
-            trie.insert(b"a", b"a").unwrap();
-            trie.insert(b"b", b"b").unwrap();
+            trie.insert(k0.as_ref(), v.as_ref()).unwrap();
+            trie.insert(k1.as_ref(), v.as_ref()).unwrap();
             trie.root().unwrap();
-            trie.remove(b"b").unwrap();
+            trie.remove(k1.as_ref()).unwrap();
             trie.root().unwrap()
         };
 
         let root3 = {
             let mut db = MemoryDB::new();
             let mut t1 = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
-            t1.insert(b"a", b"a").unwrap();
-            t1.insert(b"b", b"b").unwrap();
+            t1.insert(k0.as_ref(), v.as_ref()).unwrap();
+            t1.insert(k1.as_ref(), v.as_ref()).unwrap();
+            t1.root().unwrap();
             let root = t1.root().unwrap();
             let mut t2 = PatriciaTrie::from(&mut db, RLPNodeCodec::default(), &root).unwrap();
-            t2.remove(b"b").unwrap();
+            t2.remove(k1.as_ref()).unwrap();
             t2.root().unwrap()
         };
 


### PR DESCRIPTION
fix #14 

"pair" is an abstraction of `leaf node` and `ext node`. The value of the `ext node` is different from the value of the `leaf node`. It is not correct to decode the value into `data`.