### PR TITLE
 avoid unnecessarily clone in insert function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,9 @@ tiny-keccak = "1.4.2"
 [dev-dependencies]
 rand = "0.6.3"
 hex = "0.3.2"
+criterion = "0.2.10"
 ethereum-types = "0.5.2"
+
+[[bench]]
+name = "insert_benchmark"
+harness = false

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -1,20 +1,22 @@
-use criterion::{criterion_main, criterion_group, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
-use cita_trie::trie::{Trie, PatriciaTrie};
-use cita_trie::db::MemoryDB;
 use cita_trie::codec::RLPNodeCodec;
+use cita_trie::db::MemoryDB;
+use cita_trie::trie::{PatriciaTrie, Trie};
 
 fn insert_worse_case_benchmark(c: &mut Criterion) {
-    c.bench_function("insert 100 items", |b| b.iter(|| {
-        let mut memdb = MemoryDB::new();
-        let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
-        const N: usize = 100;
-        let mut buf = Vec::new();
-        for i in 0..N {
-            buf.push(i as u8);
-            trie.insert(&buf, b"testvalue").unwrap();
-        }
-    }));
+    c.bench_function("insert 100 items", |b| {
+        b.iter(|| {
+            let mut memdb = MemoryDB::new();
+            let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
+            const N: usize = 100;
+            let mut buf = Vec::new();
+            for i in 0..N {
+                buf.push(i as u8);
+                trie.insert(&buf, b"testvalue").unwrap();
+            }
+        })
+    });
 }
 
 criterion_group!(benches, insert_worse_case_benchmark);

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_main, criterion_group, Criterion};
+
+use cita_trie::trie::{Trie, PatriciaTrie};
+use cita_trie::db::MemoryDB;
+use cita_trie::codec::RLPNodeCodec;
+
+fn insert_worse_case_benchmark(c: &mut Criterion) {
+    c.bench_function("insert 100 items", |b| b.iter(|| {
+        let mut memdb = MemoryDB::new();
+        let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
+        const N: usize = 100;
+        let mut buf = Vec::new();
+        for i in 0..N {
+            buf.push(i as u8);
+            trie.insert(&buf, b"testvalue").unwrap();
+        }
+    }));
+}
+
+criterion_group!(benches, insert_worse_case_benchmark);
+criterion_main!(benches);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use crate::nibbles::Nibbles;
+use std::mem;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Node {
@@ -9,10 +10,28 @@ pub enum Node {
     Hash(HashNode),
 }
 
+impl Node {
+    pub fn swap(&mut self, mut n: Node) -> Node {
+        mem::swap(self, &mut n);
+        n
+    }
+    pub fn take(&mut self) -> Node {
+        self.swap(Node::Empty)
+    }
+}
+
+#[test]
+fn test_swap() {
+    let mut node = Node::Leaf(LeafNode::new(&Nibbles::from_raw(b"123", true), b"123"));
+    let cp = node.clone();
+    assert_eq!(node.take(), cp);
+    assert_eq!(node, Node::Empty);
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct LeafNode {
-    key: Nibbles,
-    value: Vec<u8>,
+    pub(crate) key: Nibbles,
+    pub(crate) value: Vec<u8>,
 }
 
 impl LeafNode {
@@ -71,6 +90,10 @@ impl BranchNode {
         &self.children[i]
     }
 
+    pub fn child_mut(&mut self, i: usize) -> &mut Node {
+        &mut self.children[i]
+    }
+
     pub fn insert(&mut self, i: usize, n: Node) {
         if i == 16 {
             match n {
@@ -102,8 +125,8 @@ impl BranchNode {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExtensionNode {
-    prefix: Nibbles,
-    node: Box<Node>,
+    pub(crate) prefix: Nibbles,
+    pub(crate) node: Box<Node>,
 }
 
 impl ExtensionNode {


### PR DESCRIPTION
reduce clone from `O(n^2)` to `O(n)` where n is the trie depth.
```
before:  bench_trie_insert_worst_case ... bench: 202,780,700 ns/iter (+/- 47,220,500)
current: bench_trie_insert_worst_case ... bench:   1,902,175 ns/iter (+/- 161,597)
```