### PR TITLE
[WIP]refactor: remove root clone

### DIFF
--- a/src/trie.rs
+++ b/src/trie.rs
@@ -62,7 +62,7 @@ where
             self.remove(key)?;
             return Ok(());
         }
-        let root = self.root.clone();
+        let root = self.root.take();
         self.root = self.insert_at(root, &Nibbles::from_raw(key, true), value)?;
         Ok(())
     }


### PR DESCRIPTION
If the `node` is modified at the time of `insert` but an error occurs during the process, the necessary `clone` ensure that the `node` is consistent with the one before the `insert`.