### PR TITLE
chore: use an explicit clone

### DIFF
--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -13,7 +13,7 @@ fn insert_worse_case_benchmark(c: &mut Criterion) {
             let mut buf = Vec::new();
             for i in 0..N {
                 buf.push(i as u8);
-                trie.insert(&buf, b"testvalue").unwrap();
+                trie.insert(&buf, b"testvalue".to_vec()).unwrap();
             }
         })
     });

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -6,10 +6,8 @@ pub struct Nibbles {
 }
 
 impl Nibbles {
-    pub fn from_hex(hex: &[u8]) -> Self {
-        Nibbles {
-            hex_data: hex.to_vec(),
-        }
+    pub fn from_hex(hex: Vec<u8>) -> Self {
+        Nibbles { hex_data: hex }
     }
 
     pub fn from_raw(raw: &[u8], is_leaf: bool) -> Self {
@@ -127,7 +125,7 @@ impl Nibbles {
     }
 
     pub fn slice(&self, start: usize, end: usize) -> Nibbles {
-        Nibbles::from_hex(&self.hex_data[start..end])
+        Nibbles::from_hex(self.hex_data[start..end].to_vec())
     }
 
     pub fn get_data(&self) -> &[u8] {
@@ -138,7 +136,7 @@ impl Nibbles {
         let mut hex_data = vec![];
         hex_data.extend_from_slice(self.get_data());
         hex_data.extend_from_slice(b.get_data());
-        Nibbles::from_hex(&hex_data)
+        Nibbles::from_hex(hex_data)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,7 +22,10 @@ impl Node {
 
 #[test]
 fn test_swap() {
-    let mut node = Node::Leaf(LeafNode::new(&Nibbles::from_raw(b"123", true), b"123"));
+    let mut node = Node::Leaf(LeafNode::new(
+        Nibbles::from_raw(b"123", true),
+        b"123".to_vec(),
+    ));
     let cp = node.clone();
     assert_eq!(node.take(), cp);
     assert_eq!(node, Node::Empty);
@@ -35,11 +38,8 @@ pub struct LeafNode {
 }
 
 impl LeafNode {
-    pub fn new(key: &Nibbles, value: &[u8]) -> Self {
-        LeafNode {
-            key: key.clone(),
-            value: value.to_vec(),
-        }
+    pub fn new(key: Nibbles, value: Vec<u8>) -> Self {
+        LeafNode { key, value }
     }
 
     pub fn get_value(&self) -> &[u8] {
@@ -98,7 +98,7 @@ impl BranchNode {
         if i == 16 {
             match n {
                 Node::Leaf(leaf) => {
-                    self.value = Some(leaf.get_value().to_vec());
+                    self.value = Some(leaf.value);
                 }
                 _ => panic!("The n must be leaf node"),
             }
@@ -130,9 +130,9 @@ pub struct ExtensionNode {
 }
 
 impl ExtensionNode {
-    pub fn new(prefix: &Nibbles, node: Node) -> Self {
+    pub fn new(prefix: Nibbles, node: Node) -> Self {
         ExtensionNode {
-            prefix: prefix.clone(),
+            prefix,
             node: Box::new(node),
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -87,8 +87,8 @@ mod trie_tests {
     fn assert_root(data: Vec<(&[u8], &[u8])>, hash: &str) {
         let mut memdb = MemoryDB::new();
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
-        for (k, v) in data.iter() {
-            trie.insert(k, v).unwrap();
+        for (k, v) in data.into_iter() {
+            trie.insert(k, v.to_vec()).unwrap();
         }
         let r = format!("0x{}", hex::encode(trie.root().unwrap()));
         assert_eq!(r.as_str(), hash);


### PR DESCRIPTION
Use an explicit clone in `ExtensionNode::new`.
Use an explicit clone in `LeafNode::new`, `value.to_vec()` is a implicit clone.
Use an explicit clone in `Nibbles::from_hex`.

If in the function signature we use reference and inside the function body we clone the reference content, it's better we pass the real content in.

eg:

```
fn foo(a: &str) {
    a.clone()
    ...
}

fn bar(a: String) {
     foo(&a)
     foo(&a)
}
```

a better way is

```
fn foo(a: String) {
    a
    ...
}

fn bar(a: String) {
     foo(a.clone())
     foo(a)
}
```
There are two reasons:
1. avoid some clone.
2. explict function signature.