### PR TITLE
refactor: Implement debug trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The implementation is strongly inspired by [go-ethereum trie](https://github.com
 ### DB
 
 ```rust
-pub trait DB: Send + Sync {
+/// NOTE: `Clone` must be ensured to be thread-safe.
+pub trait DB: Send + Sync + Clone {
     type Error: ::std::error::Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ The implementation is strongly inspired by [go-ethereum trie](https://github.com
 ### DB
 
 ```rust
-/// NOTE: `Clone` must be ensured to be thread-safe.
-pub trait DB: Send + Sync + Debug + Clone {
-    type Error: Error;
+pub trait DB: Send + Sync {
+    type Error: ::std::error::Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
     fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), Self::Error>;
@@ -33,7 +32,7 @@ pub trait DB: Send + Sync + Debug + Clone {
 ### Decoder
 
 ```rust
-pub trait NodeCodec: Sized + Debug {
+pub trait NodeCodec: Sized {
     type Error: ::std::error::Error;
 
     const HASH_LENGTH: usize;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use std::hash;
 
 use crate::errors::RLPCodecError;
@@ -13,7 +12,7 @@ pub enum DataType<'a> {
     Hash(&'a [u8]),
 }
 
-pub trait NodeCodec: Sized + Debug {
+pub trait NodeCodec: Sized {
     type Error: ::std::error::Error;
 
     const HASH_LENGTH: usize;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 use std::error::Error;
-use std::fmt::Debug;
 use std::sync::{Arc, RwLock};
 
 use crate::errors::MemDBError;
 
 /// NOTE: `Clone` must be ensured to be thread-safe.
-pub trait DB: Send + Sync + Debug + Clone {
+pub trait DB: Send + Sync + Clone {
     type Error: Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use crate::codec::NodeCodec;
 use crate::db::DB;
 
-#[derive(Debug)]
 pub enum TrieError<C: NodeCodec, D: DB> {
     NodeCodec(C::Error),
     DB(D::Error),
@@ -40,25 +39,15 @@ where
     }
 }
 
-// impl<C, D> From<C> for TrieError<C, D>
-// where
-//     C: NodeCodec,
-//     D: DB,
-// {
-//     fn from(error: C::Error) -> Self {
-//         TrieError::NodeCodec(error)
-//     }
-// }
-//
-// impl<C, D> From<C> for TrieError<C, D>
-// where
-//     C: NodeCodec,
-//     D: DB,
-// {
-//     fn from(error: D::Error) -> Self {
-//         TrieError::DB(error)
-//     }
-// }
+impl<C, D> fmt::Debug for TrieError<C, D>
+where
+    C: NodeCodec,
+    D: DB,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MemDBError {}


### PR DESCRIPTION
Implement `debug` internally to avoid the hassle of external users.