### PR TITLE
refactor: Add light mode for mem db.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ use cita_trie::db::MemoryDB;
 use cita_trie::trie::{PatriciaTrie, Trie};
 
 fn main() {
-    let mut memdb = MemoryDB::new();
+    let mut memdb = MemoryDB::new(true);
     let key = "test-key".as_bytes();
     let value = "test-value".as_bytes();
 

--- a/benches/insert_benchmark.rs
+++ b/benches/insert_benchmark.rs
@@ -7,7 +7,7 @@ use cita_trie::trie::{PatriciaTrie, Trie};
 fn insert_worse_case_benchmark(c: &mut Criterion) {
     c.bench_function("insert 100 items", |b| {
         b.iter(|| {
-            let mut memdb = MemoryDB::new();
+            let mut memdb = MemoryDB::new(true);
             let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
             const N: usize = 100;
             let mut buf = Vec::new();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -85,7 +85,7 @@ mod trie_tests {
     use crate::trie::{PatriciaTrie, Trie};
 
     fn assert_root(data: Vec<(&[u8], &[u8])>, hash: &str) {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         for (k, v) in data.iter() {
             trie.insert(k, v).unwrap();

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -526,14 +526,14 @@ mod tests {
 
     #[test]
     fn test_trie_insert() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         trie.insert(b"test", b"test").unwrap();
     }
 
     #[test]
     fn test_trie_get() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         trie.insert(b"test", b"test").unwrap();
         let v = trie.get(b"test").unwrap().map(|v| v.to_vec());
@@ -543,7 +543,7 @@ mod tests {
 
     #[test]
     fn test_trie_random_insert() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
 
         for _ in 0..1000 {
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_trie_contains() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         trie.insert(b"test", b"test").unwrap();
         assert_eq!(true, trie.contains(b"test").unwrap());
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn test_trie_remove() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         trie.insert(b"test", b"test").unwrap();
         let removed = trie.remove(b"test").unwrap();
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_trie_random_remove() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
 
         for _ in 0..1000 {
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_trie_empty_commit() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
 
         let codec = RLPNodeCodec::default();
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_trie_commit() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
         trie.insert(b"test", b"test").unwrap();
         let root = trie.commit().unwrap();
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_trie_from_root() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let root = {
             let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
             trie.insert(b"test", b"test").unwrap();
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_trie_from_root_and_insert() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let root = {
             let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
             trie.insert(b"test", b"test").unwrap();
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn test_trie_from_root_and_delete() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let root = {
             let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
             trie.insert(b"test", b"test").unwrap();
@@ -686,14 +686,14 @@ mod tests {
         let v: ethereum_types::H256 = 0x1234.into();
 
         let root1 = {
-            let mut db = MemoryDB::new();
+            let mut db = MemoryDB::new(true);
             let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
             trie.insert(k0.as_ref(), v.as_ref()).unwrap();
             trie.root().unwrap()
         };
 
         let root2 = {
-            let mut db = MemoryDB::new();
+            let mut db = MemoryDB::new(true);
             let mut trie = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
             trie.insert(k0.as_ref(), v.as_ref()).unwrap();
             trie.insert(k1.as_ref(), v.as_ref()).unwrap();
@@ -703,7 +703,7 @@ mod tests {
         };
 
         let root3 = {
-            let mut db = MemoryDB::new();
+            let mut db = MemoryDB::new(true);
             let mut t1 = PatriciaTrie::new(&mut db, RLPNodeCodec::default());
             t1.insert(k0.as_ref(), v.as_ref()).unwrap();
             t1.insert(k1.as_ref(), v.as_ref()).unwrap();
@@ -720,7 +720,7 @@ mod tests {
 
     #[test]
     fn test_delete_stale_keys_with_random_insert_and_delete() {
-        let mut memdb = MemoryDB::new();
+        let mut memdb = MemoryDB::new(true);
         let mut trie = PatriciaTrie::new(&mut memdb, RLPNodeCodec::default());
 
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
```rust
pub struct MemoryDB {
    // If "light" is true, the data is deleted from the database at the time of submission.
    light: bool,
    storage: Arc<RwLock<HashMap<Vec<u8>, Vec<u8>>>>,
}
```